### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#Fifer
+# Fifer
 
-##A lightweight conductor for the HTML5 Audio API with Flash Fallback.
+## A lightweight conductor for the HTML5 Audio API with Flash Fallback.
 
 **Author:** *Joe Harlow* (<joe@f5.io>)
 
@@ -10,7 +10,7 @@
 
 `Fifer` works best with `mp3`s as its main file type, while providing `ogg` fallbacks for Mozilla Firefox.
 
-###Browser Support
+### Browser Support
 ---
 
 `Fifer` is built on the `HTML5 Audio API`, and will attempt to preload audio files. `Mobile Safari` will not allow the preloading of audio files, however, `Fifer` will degrade gracefully and will work to some extent.
@@ -28,19 +28,19 @@
 `Fifer` will fallback to Flash in older browsers.
 
 
-###Installation
+### Installation
 ---
 
 `Fifer` can be installed with `bower`, by running:
 
 `bower install fifer`
 
-###Usage
+### Usage
 ---
 
 `Fifer` can be accessed using either `Fifer` or `fF`. From here on out, we will refer to it as `Fifer`.
 
-####`Fifer`(`config /* Object */`)
+#### `Fifer`(`config /* Object */`)
 
 `Fifer` itself is a function object. Calling `Fifer`(`config`) will set the global variables and return itself to enable chaining of functionality.
 
@@ -55,27 +55,27 @@ The `config` object can have the following properties:
 	
 	Default: `../lib/fifer.fallback.swf`.
 
-#####Example
+##### Example
 
     Fifer({
 	    force: true, // force the use of the Flash fallback
 	    swf: 'fifer/fifer.fallback.swf' // set path to Flash fallback swf
     });
     
-###Methods (chainable)
+### Methods (chainable)
 ---
 
-####`loaded`(`fn /* Function */`)
+#### `loaded`(`fn /* Function */`)
 
 The `Function` passed into the `loaded` method will be fired whenever all files in the file stack are preloaded. The first argument passed into `fn` will be the file stack from `Fifer`, `Fifer` also will be passed into the `scope` of `fn`.
 
-#####Example
+##### Example
 
     Fifer.loaded(function(files){
 		console.log(files); // logs out the file stack
 	});
 
-####`registerAudio`(`name /* String */`,`path /* String */`[, `playMultiple /* boolean : false */`])
+#### `registerAudio`(`name /* String */`,`path /* String */`[, `playMultiple /* boolean : false */`])
 
 The `registerAudio` method is used to register an audio file with `Fifer`. Once a file is registered, it is immediately preloaded from the `path` argument. The `playMultiple` argument dictates whether a file can have multiple instances played at the same time. `playMultiple` is an optional argument and defaults to false.
 
@@ -85,7 +85,7 @@ Calling `registerAudio` later in your application where the `loaded` `Function` 
 
 **N.B. To support Mozilla Firefox, `Fifer` requires both the standard `mp3` format files, along with `ogg` fallbacks. The files should be named exactly the same and in the same location. This fallback is automatic.**
 
-#####Example
+##### Example
 
     Fifer
         .loaded(function(files){
@@ -94,11 +94,11 @@ Calling `registerAudio` later in your application where the `loaded` `Function` 
 	    })
 	    .registerAudio('bang', 'bang.mp3', true);
 	    
-####`play`(`name /* String */`[,`loop /* boolean : false */`, `ended /* Function */`])
+#### `play`(`name /* String */`[,`loop /* boolean : false */`, `ended /* Function */`])
 
 The `play` method will play the audio file determined by it's name in the file stack. Providing a `loop` argument will allow you to set the file to loop indefinitely. The `ended` Function is an optional callback for when the audio file has finished playing.
 
-#####Example
+##### Example
 
     Fifer
     	/* The audio file mapped to 'bang' will be
@@ -112,27 +112,27 @@ The same can be achieved with the following:
     	   played and looped indefinitely */
         .bang(true);
 
-####`stop`([`name /* String */`])
+#### `stop`([`name /* String */`])
 
 If a `name` argument is provided, the `stop` method will stop all playing instances of that audio file.
 
 If no `name` argument is provided, all currently playing audio will stop.
 
-#####Example
+##### Example
 
     Fifer.stop('bang'); // will stop only playing instances of 'bang'
     Fifer.stop(); // will stop all playing audio
 
 
-####`stopAll`()
+#### `stopAll`()
 
 The `stopAll` method will stop all currently playing audio.
 
-#####Example
+##### Example
 
     Fifer.stopAll(); // will stop all playing audio
 
-####`mute`([`name /* String */`])
+#### `mute`([`name /* String */`])
 
 If a `name` argument is provided, the `mute` method will mute all playing instances of that audio file. 
 
@@ -140,67 +140,67 @@ If no `name` argument is provided, all audio in the file stack will be muted unt
 
 **If a file is called to play while it is registered as muted, it will play muted.**
 
-#####Example
+##### Example
 
     Fifer.mute('bang'); // all instances of 'bang' will be muted until unmuted
     Fifer.mute(); // will mute all audio until unmuted
     
-####`muteAll`()
+#### `muteAll`()
 
 The `muteAll` method will mute all audio in the stack until unmuted.
 
-#####Example
+##### Example
 
     Fifer.muteAll(); // will mute all audio until unmuted
     
-####`unmute`([`name /* String */`])
+#### `unmute`([`name /* String */`])
 
 If a `name` argument is provided, the `unmute` method will unmute all instances of that audio file. 
 
 If no `name` argument is provided, all audio in the file stack will be unmuted.
 
-#####Example
+##### Example
 
     Fifer.unmute('bang'); // all instances of 'bang' will be unmuted
     Fifer.unmute(); // will unmute all audio in the file stack
     
-####`unmuteAll`()
+#### `unmuteAll`()
 
 The `unmuteAll` method will unmute all audio in the stack.
 
-#####Example
+##### Example
 
     Fifer.unmuteAll(); // will unmute all audio in the file stack
 
-####`isPlaying`([`name /* String */`])
+#### `isPlaying`([`name /* String */`])
 
 If a `name` argument is provided, it will check to see if a specific file is playing and return a boolean.
 
 If no `name` argument is provided, it will return a boolean showing if `Fifer` is currently playing *any* audio file.
 
-#####Example
+##### Example
 
    Fifer.isPlaying('bang'); // will return true if the audio file registered as bang is playing
 
-####`onAudioProcess`([`fn /* Function */`])
+#### `onAudioProcess`([`fn /* Function */`])
 
 The `fn` argument will be called when audio is processed, either using `AudioContext` or Flash's native `computeSpectrum`. An array of values will be passed to Function containing Byte Frequency data from the audio stream.
 
 *Due to a [bug](http://stackoverflow.com/questions/13958158/why-arent-safari-or-firefox-able-to-process-audio-data-from-mediaelementsource) in Safari's handling of analyzing a MediaElementSource, Safari currently reports the array passed to the Function as empty (0) values*
 
-#####Example
+##### Example
 
    Fifer.onAudioProcess(function(arr) {
        console.log(arr);
    });
     
-####`!dynamic!`([`loop /* boolean : false */`, `ended /* Function */`])
+#### `!dynamic!`([`loop /* boolean : false */`, `ended /* Function */`])
 
 Once a file has been registered with `Fifer` and it has preloaded, `Fifer` will be extended with a `Function` named after that file.
 
 Calling this dynamic `Function` will play the file. It will also take a `loop` parameter to allow indefinite looping of the file and an `ended` callback for when the audio file has finished playing.
 
-#####Example
+##### Example
 
     Fifer.loaded(function(files){
     		/* Fifer is extended with a Function called 'aReallyLongNameThingimajig' */
@@ -208,7 +208,7 @@ Calling this dynamic `Function` will play the file. It will also take a `loop` p
 	    })
 	    .registerAudio('aReallyLongNameThingimajig', 'test.mp3', true);
     
-###License
+### License
 ---
 
 Copyright (C) 2013 Joe Harlow (Fourth of 5 Limited)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
